### PR TITLE
Configuration du mode protection

### DIFF
--- a/src/js/content.js
+++ b/src/js/content.js
@@ -36,46 +36,78 @@ function createProtectionMessage() {
   return messageDiv;
 }
 
-// Bloquer tous les éléments interactifs de la page
-function blockAllInteractiveElements(isEnabled) {
-  // Bloquer les liens
-  const links = document.getElementsByTagName('a');
-  for (const link of links) {
-    if (isEnabled) {
+// Bloquer tous les éléments interactifs de la page selon les paramètres
+function blockAllInteractiveElements(isEnabled, settings) {
+  if (!isEnabled) {
+    // Si la protection est désactivée, tout débloquer
+    unblockAll();
+    return;
+  }
+
+  // Bloquer les liens si activé dans les paramètres
+  if (settings.blockLinks) {
+    const regularLinks = document.querySelectorAll('a:not(.btn)');
+    for (const link of regularLinks) {
       link.addEventListener('click', preventNavigation);
       link.style.cursor = 'not-allowed';
-    } else {
-      link.removeEventListener('click', preventNavigation);
-      link.style.cursor = 'pointer';
     }
   }
 
-  // Bloquer les boutons
-  const buttons = document.getElementsByTagName('button');
-  for (const button of buttons) {
-    if (isEnabled) {
+  // Bloquer les inputs de type submit si activé dans les paramètres
+  if (settings.blockSubmit) {
+    const submits = document.querySelectorAll('input[type="submit"]');
+    for (const submit of submits) {
+      submit.addEventListener('click', preventNavigation);
+      submit.disabled = true;
+      submit.style.cursor = 'not-allowed';
+    }
+  }
+
+  // Bloquer les inputs de type button et les liens-boutons si activé dans les paramètres
+  if (settings.blockButton) {
+    const buttons = document.querySelectorAll('input[type="button"], button, a.btn');
+    for (const button of buttons) {
       button.addEventListener('click', preventNavigation);
-      button.disabled = true;
+      if (button.tagName.toLowerCase() !== 'a') {
+        button.disabled = true;
+      }
       button.style.cursor = 'not-allowed';
-    } else {
-      button.removeEventListener('click', preventNavigation);
-      button.disabled = false;
-      button.style.cursor = 'pointer';
+      // Empêcher aussi les événements de souris pour les liens-boutons
+      if (button.tagName.toLowerCase() === 'a') {
+        button.addEventListener('mousedown', preventNavigation);
+        button.addEventListener('mouseup', preventNavigation);
+      }
     }
   }
+}
 
-  // Bloquer les inputs de type submit et button
-  const inputs = document.querySelectorAll('input[type="submit"], input[type="button"]');
-  for (const input of inputs) {
-    if (isEnabled) {
-      input.addEventListener('click', preventNavigation);
-      input.disabled = true;
-      input.style.cursor = 'not-allowed';
-    } else {
-      input.removeEventListener('click', preventNavigation);
-      input.disabled = false;
-      input.style.cursor = 'pointer';
+// Fonction pour débloquer tous les éléments
+function unblockAll() {
+  // Débloquer les liens réguliers
+  const regularLinks = document.querySelectorAll('a:not(.btn)');
+  for (const link of regularLinks) {
+    link.removeEventListener('click', preventNavigation);
+    link.style.cursor = 'pointer';
+  }
+
+  // Débloquer les inputs de type submit
+  const submits = document.querySelectorAll('input[type="submit"]');
+  for (const submit of submits) {
+    submit.removeEventListener('click', preventNavigation);
+    submit.disabled = false;
+    submit.style.cursor = 'pointer';
+  }
+
+  // Débloquer les inputs de type button, les boutons et les liens-boutons
+  const buttons = document.querySelectorAll('input[type="button"], button, a.btn');
+  for (const button of buttons) {
+    button.removeEventListener('click', preventNavigation);
+    button.removeEventListener('mousedown', preventNavigation);
+    button.removeEventListener('mouseup', preventNavigation);
+    if (button.tagName.toLowerCase() !== 'a') {
+      button.disabled = false;
     }
+    button.style.cursor = 'pointer';
   }
 }
 
@@ -86,7 +118,7 @@ function preventNavigation(event) {
 }
 
 // Observer les modifications du DOM pour bloquer les nouveaux liens
-function setupMutationObserver(isEnabled) {
+function setupMutationObserver(isEnabled, settings) {
   if (window.mockifyObserver) {
     window.mockifyObserver.disconnect();
   }
@@ -95,7 +127,7 @@ function setupMutationObserver(isEnabled) {
     window.mockifyObserver = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.addedNodes.length) {
-          blockAllInteractiveElements(true);
+          blockAllInteractiveElements(true, settings);
         }
       });
     });
@@ -108,7 +140,7 @@ function setupMutationObserver(isEnabled) {
 }
 
 // Gérer l'affichage du message et le blocage des liens
-function handleProtectionMessage(isEnabled) {
+function handleProtectionMessage(isEnabled, settings) {
   let messageDiv = document.getElementById('mockify-protection-message');
   
   if (isEnabled) {
@@ -116,25 +148,50 @@ function handleProtectionMessage(isEnabled) {
       messageDiv = createProtectionMessage();
       document.body.appendChild(messageDiv);
     }
-    blockAllInteractiveElements(true);
-    setupMutationObserver(true);
+    blockAllInteractiveElements(true, settings);
+    setupMutationObserver(true, settings);
   } else {
     if (messageDiv) {
       messageDiv.remove();
     }
-    blockAllInteractiveElements(false);
-    setupMutationObserver(false);
+    blockAllInteractiveElements(false, settings);
+    setupMutationObserver(false, settings);
   }
 }
 
-// Écouter les changements d'état de la protection
-chrome.storage.local.get(['protectionEnabled'], function(result) {
-  handleProtectionMessage(result.protectionEnabled || false);
+// Écouter les changements d'état de la protection et des paramètres
+chrome.storage.local.get([
+  'protectionEnabled',
+  'blockLinks',
+  'blockSubmit',
+  'blockButton'
+], function(result) {
+  const settings = {
+    blockLinks: result.blockLinks !== false,
+    blockSubmit: result.blockSubmit !== false,
+    blockButton: result.blockButton !== false
+  };
+  handleProtectionMessage(result.protectionEnabled || false, settings);
 });
 
-// Écouter les mises à jour de l'état
+// Écouter les mises à jour de l'état et des paramètres
 chrome.storage.onChanged.addListener(function(changes) {
-  if (changes.protectionEnabled) {
-    handleProtectionMessage(changes.protectionEnabled.newValue);
-  }
+  chrome.storage.local.get([
+    'protectionEnabled',
+    'blockLinks',
+    'blockSubmit',
+    'blockButton'
+  ], function(result) {
+    const settings = {
+      blockLinks: result.blockLinks !== false,
+      blockSubmit: result.blockSubmit !== false,
+      blockButton: result.blockButton !== false
+    };
+    
+    if (changes.protectionEnabled) {
+      handleProtectionMessage(changes.protectionEnabled.newValue, settings);
+    } else if (changes.blockLinks || changes.blockSubmit || changes.blockButton) {
+      handleProtectionMessage(result.protectionEnabled || false, settings);
+    }
+  });
 });

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -36,8 +36,9 @@ function createProtectionMessage() {
   return messageDiv;
 }
 
-// Bloquer tous les liens de la page
-function blockAllLinks(isEnabled) {
+// Bloquer tous les éléments interactifs de la page
+function blockAllInteractiveElements(isEnabled) {
+  // Bloquer les liens
   const links = document.getElementsByTagName('a');
   for (const link of links) {
     if (isEnabled) {
@@ -46,6 +47,38 @@ function blockAllLinks(isEnabled) {
     } else {
       link.removeEventListener('click', preventNavigation);
       link.style.cursor = 'pointer';
+    }
+  }
+
+  // Bloquer les boutons
+  const buttons = document.getElementsByTagName('button');
+  for (const button of buttons) {
+    if (isEnabled) {
+      button.addEventListener('click', preventNavigation);
+      button.disabled = true;
+      button.style.cursor = 'not-allowed';
+      button.style.opacity = '0.6';
+    } else {
+      button.removeEventListener('click', preventNavigation);
+      button.disabled = false;
+      button.style.cursor = 'pointer';
+      button.style.opacity = '1';
+    }
+  }
+
+  // Bloquer les inputs de type submit et button
+  const inputs = document.querySelectorAll('input[type="submit"], input[type="button"]');
+  for (const input of inputs) {
+    if (isEnabled) {
+      input.addEventListener('click', preventNavigation);
+      input.disabled = true;
+      input.style.cursor = 'not-allowed';
+      input.style.opacity = '0.6';
+    } else {
+      input.removeEventListener('click', preventNavigation);
+      input.disabled = false;
+      input.style.cursor = 'pointer';
+      input.style.opacity = '1';
     }
   }
 }
@@ -66,7 +99,7 @@ function setupMutationObserver(isEnabled) {
     window.mockifyObserver = new MutationObserver((mutations) => {
       mutations.forEach((mutation) => {
         if (mutation.addedNodes.length) {
-          blockAllLinks(true);
+          blockAllInteractiveElements(true);
         }
       });
     });
@@ -87,13 +120,13 @@ function handleProtectionMessage(isEnabled) {
       messageDiv = createProtectionMessage();
       document.body.appendChild(messageDiv);
     }
-    blockAllLinks(true);
+    blockAllInteractiveElements(true);
     setupMutationObserver(true);
   } else {
     if (messageDiv) {
       messageDiv.remove();
     }
-    blockAllLinks(false);
+    blockAllInteractiveElements(false);
     setupMutationObserver(false);
   }
 }

--- a/src/js/content.js
+++ b/src/js/content.js
@@ -57,12 +57,10 @@ function blockAllInteractiveElements(isEnabled) {
       button.addEventListener('click', preventNavigation);
       button.disabled = true;
       button.style.cursor = 'not-allowed';
-      button.style.opacity = '0.6';
     } else {
       button.removeEventListener('click', preventNavigation);
       button.disabled = false;
       button.style.cursor = 'pointer';
-      button.style.opacity = '1';
     }
   }
 
@@ -73,12 +71,10 @@ function blockAllInteractiveElements(isEnabled) {
       input.addEventListener('click', preventNavigation);
       input.disabled = true;
       input.style.cursor = 'not-allowed';
-      input.style.opacity = '0.6';
     } else {
       input.removeEventListener('click', preventNavigation);
       input.disabled = false;
       input.style.cursor = 'pointer';
-      input.style.opacity = '1';
     }
   }
 }


### PR DESCRIPTION
# Ajout de la configuration du mode protection

## 🎯 Objectif
Cette PR ajoute une section "Settings" dans le popup de l'extension permettant de configurer finement le comportement du mode protection, notamment en choisissant quels types d'éléments doivent être bloqués.

## ✨ Nouvelles fonctionnalités
- Ajout d'une section "Settings" dans le popup
- Sous-section "Reload protection" avec 3 toggles configurables :
  - `Links` : Contrôle le blocage des liens standards
  - `Input submit` : Contrôle le blocage des boutons de type submit
  - `Input button` : Contrôle le blocage des boutons et liens-boutons

## 🔧 Modifications techniques
- Refactorisation du système de blocage pour supporter la configuration granulaire
- Amélioration de la gestion des liens-boutons (classe `.btn`)
- Ajout d'événements supplémentaires (`mousedown`, `mouseup`) pour un blocage plus robuste
- Persistance des préférences dans le stockage local de Chrome
- Gestion des changements dynamiques du DOM via MutationObserver

## 🎨 UI/UX
- Nouvelle section "Settings" avec un design cohérent
- Toggles individuels pour chaque type de blocage
- État par défaut des toggles : activé
- Retour visuel clair avec curseur "not-allowed" et désactivation des éléments

## 🐛 Corrections de bugs
- Correction du blocage des liens avec la classe `.btn`
- Amélioration de la gestion des événements pour éviter les contournements
- Meilleure séparation entre les liens standards et les liens-boutons

## 📝 Notes
- Les paramètres sont sauvegardés et restaurés lors du rechargement de la page
- La configuration est appliquée en temps réel sans nécessiter de rechargement
- Le mode protection principal doit être activé pour que les blocages individuels fonctionnent

## 🧪 Tests effectués
- Vérification du fonctionnement des toggles individuels
- Test du blocage des différents types d'éléments
- Validation de la persistance des paramètres
- Test sur les éléments ajoutés dynamiquement